### PR TITLE
Remove source directory of nvtop

### DIFF
--- a/src/Dockerfile.gpulibs
+++ b/src/Dockerfile.gpulibs
@@ -34,7 +34,7 @@ RUN git clone https://github.com/Syllo/nvtop.git /run/nvtop && \
     (cmake .. -DNVML_RETRIEVE_HEADER_ONLINE=True 2> /dev/null || echo "cmake was not successful") && \
     (make 2> /dev/null || echo "make was not successful") && \
     (make install 2> /dev/null || echo "make install was not successful") && \
-    cd /tmp && rm -rf /tmp/nvtop
+    rm -rf /run/nvtop
 
 RUN fix-permissions /home/$NB_USER
 


### PR DESCRIPTION
This removes the source directory of nvtop after building and installing it. Also the `cd` command was unnecessary. This fixes #94.